### PR TITLE
Add calculator gRPC service

### DIFF
--- a/proto/helloworld.proto
+++ b/proto/helloworld.proto
@@ -5,10 +5,26 @@ service Greeter {
   rpc SayHello (HelloRequest) returns (HelloReply);
 }
 
+service Calculator {
+  rpc Add (CalcRequest) returns (CalcReply);
+  rpc Subtract (CalcRequest) returns (CalcReply);
+  rpc Multiply (CalcRequest) returns (CalcReply);
+  rpc Divide (CalcRequest) returns (CalcReply);
+}
+
 message HelloRequest {
   string name = 1;
 }
 
 message HelloReply {
   string message = 1;
+}
+
+message CalcRequest {
+  int32 a = 1;
+  int32 b = 2;
+}
+
+message CalcReply {
+  int32 result = 1;
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,6 @@
 use helloworld::greeter_client::GreeterClient;
-use helloworld::HelloRequest;
+use helloworld::calculator_client::CalculatorClient;
+use helloworld::{HelloRequest, CalcRequest};
 
 pub mod helloworld {
     tonic::include_proto!("helloworld");
@@ -7,15 +8,20 @@ pub mod helloworld {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = GreeterClient::connect("http://[::1]:50051").await?;
+    let mut greeter = GreeterClient::connect("http://[::1]:50051").await?;
+    let mut calculator = CalculatorClient::connect("http://[::1]:50051").await?;
 
     let request = tonic::Request::new(HelloRequest {
         name: "Tonic".into(),
     });
 
-    let response = client.say_hello(request).await?;
+    let response = greeter.say_hello(request).await?;
 
     println!("RESPONSE={:?}", response);
+
+    let calc_request = tonic::Request::new(CalcRequest { a: 10, b: 5 });
+    let add_response = calculator.add(calc_request).await?;
+    println!("ADD RESPONSE={:?}", add_response);
 
     Ok(())
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,7 +1,8 @@
 use tonic::{transport::Server, Request, Response, Status};
 
 use hello_world::greeter_server::{Greeter, GreeterServer};
-use hello_world::{HelloReply, HelloRequest};
+use hello_world::calculator_server::{Calculator, CalculatorServer};
+use hello_world::{HelloReply, HelloRequest, CalcRequest, CalcReply};
 
 pub mod hello_world {
     tonic::include_proto!("helloworld");
@@ -9,6 +10,9 @@ pub mod hello_world {
 
 #[derive(Default, Debug)]
 pub struct MyGreeter {}
+
+#[derive(Default, Debug)]
+pub struct MyCalculator {}
 
 #[tonic::async_trait]
 impl Greeter for MyGreeter {
@@ -26,13 +30,57 @@ impl Greeter for MyGreeter {
     }
 }
 
+#[tonic::async_trait]
+impl Calculator for MyCalculator {
+    async fn add(
+        &self,
+        request: Request<CalcRequest>,
+    ) -> Result<Response<CalcReply>, Status> {
+        let r = request.into_inner();
+        let reply = hello_world::CalcReply { result: r.a + r.b };
+        Ok(Response::new(reply))
+    }
+
+    async fn subtract(
+        &self,
+        request: Request<CalcRequest>,
+    ) -> Result<Response<CalcReply>, Status> {
+        let r = request.into_inner();
+        let reply = hello_world::CalcReply { result: r.a - r.b };
+        Ok(Response::new(reply))
+    }
+
+    async fn multiply(
+        &self,
+        request: Request<CalcRequest>,
+    ) -> Result<Response<CalcReply>, Status> {
+        let r = request.into_inner();
+        let reply = hello_world::CalcReply { result: r.a * r.b };
+        Ok(Response::new(reply))
+    }
+
+    async fn divide(
+        &self,
+        request: Request<CalcRequest>,
+    ) -> Result<Response<CalcReply>, Status> {
+        let r = request.into_inner();
+        if r.b == 0 {
+            return Err(Status::invalid_argument("division by zero"));
+        }
+        let reply = hello_world::CalcReply { result: r.a / r.b };
+        Ok(Response::new(reply))
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "[::1]:50051".parse()?;
     let greeter = MyGreeter::default();
+    let calculator = MyCalculator::default();
 
     Server::builder()
         .add_service(GreeterServer::new(greeter))
+        .add_service(CalculatorServer::new(calculator))
         .serve(addr)
         .await?;
 


### PR DESCRIPTION
## Summary
- add basic arithmetic RPC service definitions in proto
- implement `Calculator` server with add/subtract/multiply/divide endpoints
- update client to call the new add RPC

## Testing
- `cargo check` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6844d7d20504832d924ec91e2a309419